### PR TITLE
fix: Project component use css media query instead of javascript,.

### DIFF
--- a/Components/Project/Project.module.scss
+++ b/Components/Project/Project.module.scss
@@ -44,6 +44,7 @@
 
       @include respond(mobileLarge) {
         opacity: 0 !important;
+        display: none !important;
       }
 
       @include respond(mobileSmall) {
@@ -58,6 +59,7 @@
 
       @include respond(mobileLarge) {
         margin: 0 auto;
+        order: 0 !important;
       }
 
       &__image {
@@ -71,6 +73,7 @@
       @include respond(mobileLarge) {
         text-align: center;
         margin: 0 auto !important;
+        order: 0 !important;
       }
 
       @include respond(mobileSmall) {

--- a/Components/Project/Project.tsx
+++ b/Components/Project/Project.tsx
@@ -21,6 +21,33 @@ const Project: React.FC<Props> = ({
   to,
   isMobile,
 }) => {
+  if (isMobile) {
+    return (
+      <a href={to} className={styles.link} target="_blank">
+        <div className={styles.container}>
+          <div
+            className={styles.readmore}
+            style={{ top: "50%", right: "5%", transform: "translateY(-50%)" }}
+          >
+            Check it out!
+          </div>
+          <div className={styles.imageContainer}>
+            <Image
+              className={styles.imageContainer__image}
+              layout="fill"
+              objectFit="cover"
+              src={imgurl}
+            />
+          </div>
+          <div className={styles.content} style={{ marginLeft: "5rem" }}>
+            <h2 className={styles.title}>{title}</h2>
+            <div className={styles.about}>{about}</div>
+          </div>
+        </div>
+      </a>
+    );
+  }
+
   if (ltr) {
     return (
       <a href={to} className={styles.link} target="_blank">

--- a/Components/Project/Project.tsx
+++ b/Components/Project/Project.tsx
@@ -10,89 +10,42 @@ interface Props {
   about: string;
   imgurl: string;
   to: string;
-  isMobile: Boolean;
 }
 
 const Project: React.FC<Props> = ({
-  ltr,
+  ltr = false,
   title,
   about,
   imgurl,
   to,
-  isMobile,
 }) => {
-  if (isMobile) {
-    return (
-      <a href={to} className={styles.link} target="_blank">
-        <div className={styles.container}>
-          <div
-            className={styles.readmore}
-            style={{ top: "50%", right: "5%", transform: "translateY(-50%)" }}
-          >
-            Check it out!
-          </div>
-          <div className={styles.imageContainer}>
-            <Image
-              className={styles.imageContainer__image}
-              layout="fill"
-              objectFit="cover"
-              src={imgurl}
-            />
-          </div>
-          <div className={styles.content} style={{ marginLeft: "5rem" }}>
-            <h2 className={styles.title}>{title}</h2>
-            <div className={styles.about}>{about}</div>
-          </div>
-        </div>
-      </a>
-    );
-  }
-
-  if (ltr) {
-    return (
-      <a href={to} className={styles.link} target="_blank">
-        <div className={styles.container}>
-          <div
-            className={styles.readmore}
-            style={{ top: "50%", left: "5%", transform: "translateY(-50%)" }}
-          >
-            Check it out!
-          </div>
-          <div className={styles.content} style={{ marginRight: "5rem" }}>
-            <h2 className={styles.title}>{title}</h2>
-            <div className={styles.about}>{about}</div>
-          </div>
-          <div className={styles.imageContainer}>
-            <Image
-              className={styles.imageContainer__image}
-              layout="fill"
-              objectFit="cover"
-              src={imgurl}
-            />
-          </div>
-        </div>
-      </a>
-    );
-  }
-
   return (
     <a href={to} className={styles.link} target="_blank">
       <div className={styles.container}>
         <div
           className={styles.readmore}
-          style={{ top: "50%", right: "5%", transform: "translateY(-50%)" }}
+          style={{
+            top: "50%",
+            right: ltr ? "auto" : "5%",
+            left: ltr ? "5%" : "auto",
+            transform: "translateY(-50%)",
+          }}
         >
           Check it out!
         </div>
-        <div className={styles.imageContainer}>
+        <div className={styles.imageContainer} style={{ order: ltr ? 3 : 2 }}>
           <Image
             className={styles.imageContainer__image}
             layout="fill"
             objectFit="cover"
             src={imgurl}
+            alt={title}
           />
         </div>
-        <div className={styles.content} style={{ marginLeft: "5rem" }}>
+        <div
+          className={styles.content}
+          style={{ marginLeft: "5rem", order: ltr ? 2 : 3 }}
+        >
           <h2 className={styles.title}>{title}</h2>
           <div className={styles.about}>{about}</div>
         </div>

--- a/Components/Projects/Projects.tsx
+++ b/Components/Projects/Projects.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect } from "react";
-import { useMediaQuery } from "react-responsive";
 
 // Styles and animations
 import styles from "./Projects.module.scss";
@@ -14,8 +13,6 @@ interface Props {
 
 const Projects: React.FC<Props> = ({ isVisible }) => {
   const containerControl = useAnimation();
-
-  const isMobile = useMediaQuery({ query: "(max-width: 425px)" });
 
   useEffect(() => {
     if (isVisible) {
@@ -70,7 +67,6 @@ const Projects: React.FC<Props> = ({ isVisible }) => {
       >
         <Project
           title="Althemic"
-          isMobile={isMobile}
           to="/projects/althemic"
           imgurl="/images/projects/natours/natours-normal.png"
           about="A travel booking website made using Nodejs, MongoDB, and Express.js. This was my very first project through which I ever learned!"
@@ -85,7 +81,6 @@ const Projects: React.FC<Props> = ({ isVisible }) => {
       >
         <Project
           title="Natours"
-          isMobile={isMobile}
           to="https://natours-sourav.herokuapp.com"
           imgurl="/images/projects/natours/natours-normal.png"
           about="A travel booking website made using Nodejs, MongoDB, and Express.js. This was my very first project through which I ever learned!"
@@ -99,7 +94,6 @@ const Projects: React.FC<Props> = ({ isVisible }) => {
       >
         <Project
           title="Emage"
-          isMobile={isMobile}
           to="https://emageical.herokuapp.com"
           imgurl="/images/projects/emage/emage-normal.png"
           about="A web app to upload and host images for free. Provides a direct route to imgur API so there is no need of authentication."
@@ -113,7 +107,6 @@ const Projects: React.FC<Props> = ({ isVisible }) => {
         animate="visible"
       >
         <Project
-          isMobile={isMobile}
           title="Emageically"
           to="https://emageically.netlify.app/"
           about="Website just like Unsplash where you can upload free-to-use images and can download them for free. The website also allows users to anonymously upload images."
@@ -127,7 +120,6 @@ const Projects: React.FC<Props> = ({ isVisible }) => {
         animate="visible"
       >
         <Project
-          isMobile={isMobile}
           title="Reactive Clothing"
           to="https://reactive-clothing-live.herokuapp.com/"
           about="An e-commerce site built using React and Redux. Light and fast as it can be!"
@@ -142,7 +134,6 @@ const Projects: React.FC<Props> = ({ isVisible }) => {
         animate="visible"
       >
         <Project
-          isMobile={isMobile}
           title="Trillo"
           to="https://frostzt.github.io/Trilloproject/"
           about="A static website that I built to learn SASS and advanced CSS/SASS!"
@@ -156,7 +147,6 @@ const Projects: React.FC<Props> = ({ isVisible }) => {
         animate="visible"
       >
         <Project
-          isMobile={isMobile}
           title="Snake Game"
           to="https://frostzt.github.io/snake-game/"
           about="You can guess what this one does, eh? I mean who haven't played this! Its GOLD!"


### PR DESCRIPTION
https://github.com/vercel/next.js/issues/25748

When the server renders the page it doesn't know the users browser width to be able to do the javascript check for [`isMobile`](https://github.com/frostzt/frostzt/compare/master...andykenward:feat/fix?expand=1#diff-cec1af775f9354a37577b6da3caa472a110fabfa536cbfcccdd1babce467d23bL18).
```
const isMobile = useMediaQuery({ query: "(max-width: 425px)" });
```

☝🏻 On the server this will always be false.

When next.js + framer motion try to rehydrate the page client side. The `isMobile` may be `true` for the users browser. But next.js / framer motion can't rehydate the component correctly.

I thought it might have to do with needing [React keys](https://reactjs.org/docs/glossary.html#keys) on certain elements to solve the rehydrate issue. But looking at how you are using `isMobile` it is better to move that logic to css and add a [`display:none` to `.readmore`](https://github.com/frostzt/frostzt/compare/master...andykenward:feat/fix?expand=1#diff-827b04056ffbdfe3f8f94bffcc3aa1d0de8bd2a0fdf699c23dab5139fbfad746R47) at the correct breakpoint.

I've also simplfied the `ltr` logic you had to use css [`order`](https://developer.mozilla.org/en-US/docs/Web/CSS/order) instead.
